### PR TITLE
Harden installer preservation and Quickshare deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ conflict; fresh installations use Arch's `quickshell` package.
 
 ## Release status
 
-`v0.1.0` is Tsugumori's first public beta, not a stable release. A clean Arch VM
-installation completed on 2026-08-15 with official Quickshell 0.3.0-2 and
-Hyprland 0.56.2-1; the feature-complete candidate passed all 48 tests and the
-required Hyprland/QML integration checks there. The release tree is also covered
-by the same required Arch checks in GitHub Actions. See the
-[`v0.1.0` release notes](RELEASE_NOTES.md) for known limitations.
+`v0.1.1` is a targeted safety hotfix for Tsugumori's public beta, not a stable
+release. It hardens installer override preservation and adds bounded Quickshare
+send and Cloudflare-tunnel startup deadlines. The focused installer and
+Quickshare test suites cover the hotfix locally, while the complete release tree
+remains gated by the required Arch checks in GitHub Actions. See the
+[`v0.1.1` release notes](RELEASE_NOTES.md) for known limitations.
 
 ## Control Center
 
@@ -92,6 +92,9 @@ A NieR:Automata-style radial menu with Knights of Sidonia theme accessible via `
   - Pick files via a floating Yazi instance and share them over the local network
   - Scan a tokenized QR code from a phone to send or receive files
   - Optionally expose a temporary HTTPS Cloudflare tunnel for remote transfers
+  - Send mode uses a fixed 15-second absolute request-header deadline and a
+    five-minute absolute download deadline by default. Use
+    `qshare send --transfer-timeout SECONDS` to adjust the download deadline.
   - Receive mode defaults to a 1 GiB request limit, 4 GiB cumulative session
     limit, 32 files per request, 128 files per session, at most 16 active
     connections, a request-header deadline capped at 15 seconds, and a

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,85 +1,53 @@
-# Tsugumori v0.1.0
+# Tsugumori v0.1.1
 
-Tsugumori `v0.1.0` is the first credible beta of the Knights of
-Sidonia-inspired Arch Linux desktop. It focuses on safe installation, a native
-Hyprland Lua configuration, and closing the security gaps found during the
-pre-release audit.
+Tsugumori `v0.1.1` is a focused safety hotfix for the public beta. It preserves
+the `v0.1.0` feature set while hardening upgrades and Quickshare connections.
 
-## Highlights
+## Changes
 
-- Migrated the complete Hyprland configuration to native Lua. Tsugumori supports
-  Hyprland 0.55.2 or newer, and personal overrides live in a preserved
-  `user.lua` module.
-- Reworked the installer to validate both the bundled config and the exact
-  candidate config—including preserved overrides and managed VM options—before
-  deployment. Active legacy `user.conf` overrides fail closed when no native
-  `user.lua` exists; when both exist, both files are preserved and the installer
-  warns that `user.conf` remains dormant.
-- Replaced the lock overlay with real `ext-session-lock-v1` surfaces and PAM
-  authentication. A supervised startup handshake falls back to Hyprlock on an
-  import error, early exit, readiness timeout, or post-acquisition crash.
-  Duplicate lock requests are serialized across authenticated release, so a
-  suspend-time request cannot disappear during the hide animation.
-- Removed shell evaluation from wallpaper selection, made `awww` an official
-  dependency, and started `awww-daemon` with the session.
-- Moved Pomodoro state to a private XDG runtime directory, writing it with mode
-  `600` and parsing state values without sourcing executable shell code.
-- Added bounded Quickshare receiving: 1 GiB per request, 4 GiB per session, 32
-  files per request, 128 files per session, at most 16 active connections, a
-  request-header deadline capped at 15 seconds, and a five-minute overall upload
-  deadline by default. Partial uploads are cleaned up transactionally.
-- Made Arch-target integration validation mandatory in CI: ShellCheck, Python,
-  48 unit tests, Hyprland Lua parsing, and lint/import checks for all 17 QML
-  files.
-
-## Installation and migration
-
-Tsugumori supports Arch Linux with Hyprland 0.55.2 or newer and Quickshell 0.3.
-The installer creates timestamped backups by default. Existing `user.lua` and
-Quickshell settings are preserved. A legacy `user.conf` is retained as a dormant
-backup, but it is not loaded by the native Lua configuration; migrate any active
-machine-specific settings before upgrading.
-
-`--pinned` intentionally exits with an error until complete, reviewed pinned
-manifests are published. A fresh default `--latest` installation uses official
-Arch packages, including Quickshell and `awww`; an already-installed compatible
-Quickshell provider is retained during upgrades.
+- Installer preservation now handles `user.lua`, dormant `user.conf`, and
+  `Settings.qml` symlinks lexically. Relative link text survives an upgrade
+  unchanged; dangling or non-file preserved links fail closed before the
+  installed configuration is replaced.
+- `qshare send` now applies a fixed 15-second absolute request-header deadline
+  and a five-minute absolute download deadline by default. The new
+  `--transfer-timeout SECONDS` option adjusts the latter, up to the existing
+  24-hour safety maximum. A stalled or disconnected client no longer completes
+  a one-shot send, so another client can retry.
+- Cloudflare tunnel startup now reads output in the background instead of
+  blocking on `readline()`. Its existing 30-second startup limit remains in
+  force, and failed tunnel processes are terminated and reaped.
 
 ## Installing this release
 
 Pin both the downloaded installer and the revision it clones:
 
 ```bash
-TSUGUMORI_BRANCH=v0.1.0 bash <(curl -fsSL https://raw.githubusercontent.com/Aleph1-9012/Tsugumori/v0.1.0/install.sh)
+TSUGUMORI_BRANCH=v0.1.1 bash <(curl -fsSL https://raw.githubusercontent.com/Aleph1-9012/Tsugumori/v0.1.1/install.sh)
 ```
 
 The quick-install command in the README intentionally follows rolling `main`;
-the command above installs the immutable `v0.1.0` tree.
+the command above installs the immutable `v0.1.1` tree. The historical
+`v0.1.0` notes remain available from that tag and its GitHub release.
 
-## Validation record
+## Validation
 
-An installation candidate was installed from scratch in an Arch VM on
-2026-08-15 with Hyprland 0.56.2-1, official Quickshell 0.3.0-2, and official
-`awww` 0.12.1-1. Both pre-deployment Lua checks passed and the installed
-configuration parsed. After final hardening, the feature-complete candidate was
-validated again in that same official-package VM: all 48 tests, ShellCheck,
-Hyprland parsing, and all 17 QML checks passed. The release tree passed those
-same required checks in Arch CI. Hyprland 0.55.2-1 was separately verified as
-the supported minimum.
+This hotfix uses focused local installer and Quickshare unit suites, followed by
+the protected Arch `Validate` workflow as the full release gate. No additional
+VM, PAM, GPU, or multi-monitor acceptance cycle was run for this patch release.
 
 ## Known limitations
 
-- This is a beta release for rolling Arch Linux, not a distribution-independent
-  or stable desktop product.
-- The clean-VM acceptance run was headless. It validates the installer, package
-  set, configs, fallback logic, and imports, but not every animation, GPU driver,
-  display topology, or physical PAM interaction.
-- The QML shell remains a large, tightly coupled architecture. Every file passes
-  mandatory lint/import validation, but reducing its warning count and splitting
-  major widgets are post-`v0.1.0` maintenance work.
-- Reproducible `--pinned` installation is unavailable until reviewed manifests
-  are committed; the option fails closed instead of silently installing latest.
-- Quickshare's direct LAN transport is plaintext HTTP; use it only on a trusted
-  network or choose the temporary HTTPS tunnel mode. Access is bearer-token
-  based, so anyone who obtains a live LAN or tunnel URL can upload within the
-  configured limits until that receive session ends.
+- Preserving the complete tracked `Settings.qml` still makes future settings
+  migrations fragile; a narrower user-override format is deferred.
+- The README gallery still uses its original full-width source images; layout
+  and asset-size optimization are deferred.
+- Reproducible `--pinned` installation remains unavailable until reviewed
+  manifests are committed; the option continues to fail closed.
+- Live PAM, GPU, and multi-monitor acceptance remains outstanding. This is an
+  Arch Linux beta, not a stable or distribution-independent desktop release.
+- Quickshare's direct LAN transport remains plaintext HTTP and should be used
+  only on trusted networks; tunnel mode provides HTTPS but still uses bearer
+  URLs for access.
+- The QML shell remains large and tightly coupled. Splitting major widgets and
+  reducing non-fatal lint warnings remain post-beta maintenance work.

--- a/config/quickshell/scripts/qshare.py
+++ b/config/quickshell/scripts/qshare.py
@@ -18,6 +18,7 @@ from email.message import Message
 from http import HTTPStatus
 import math
 import os
+import queue
 import re
 import secrets
 import signal
@@ -72,8 +73,11 @@ DEFAULT_MAX_FILES_PER_SESSION = 128
 DEFAULT_UPLOAD_TIMEOUT = 300.0
 DEFAULT_HEADER_TIMEOUT = 15.0
 MAX_UPLOAD_TIMEOUT = min(24 * 60 * 60.0, threading.TIMEOUT_MAX)
+DEFAULT_TRANSFER_TIMEOUT = 300.0
+CLOUDFLARED_STARTUP_TIMEOUT = 30.0
 DEFAULT_MAX_CONNECTIONS = 16
 _UPLOAD_CHUNK_SIZE = 64 * 1024
+_DOWNLOAD_CHUNK_SIZE = 64 * 1024
 _MAX_MULTIPART_HEADER_LINE = 64 * 1024
 
 
@@ -240,32 +244,53 @@ def start_cloudflared(local_port: int) -> tuple[subprocess.Popen, str]:
     url_pattern = re.compile(r"https://[a-z0-9-]+\.trycloudflare\.com")
     public_url: str | None = None
     registered = False
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + CLOUDFLARED_STARTUP_TIMEOUT
+    startup_lines: queue.Queue[str | None] = queue.Queue()
+    startup_complete = threading.Event()
+
+    def _read_output() -> None:
+        # This remains the process's sole stdout reader after startup, when it
+        # switches from forwarding lines to simply draining the pipe.
+        for line in iter(proc.stdout.readline, ""):
+            if not startup_complete.is_set():
+                startup_lines.put(line)
+        if not startup_complete.is_set():
+            startup_lines.put(None)
+
+    threading.Thread(target=_read_output, daemon=True).start()
 
     print(f"{ANSI_DIM}Démarrage du tunnel Cloudflare…{ANSI_RESET}")
-    while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            if proc.poll() is not None:
-                sys.exit("cloudflared s'est arrêté avant d'établir le tunnel.")
-            continue
+    failure = "Impossible d'établir le tunnel Cloudflare (timeout)."
+    while not (public_url and registered):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            line = startup_lines.get(timeout=remaining)
+        except queue.Empty:
+            break
+        if line is None:
+            failure = "cloudflared s'est arrêté avant d'établir le tunnel."
+            break
         if not public_url:
             m = url_pattern.search(line)
             if m:
                 public_url = m.group(0)
         if "Registered tunnel connection" in line:
             registered = True
-        if public_url and registered:
-            break
 
-    if not public_url:
+    if not (public_url and registered):
+        startup_complete.set()
         proc.terminate()
-        sys.exit("Impossible de récupérer l'URL du tunnel (timeout).")
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        _CHILD_PROCESSES.discard(proc)
+        sys.exit(failure)
 
-    def _drain():
-        for _ in iter(proc.stdout.readline, ""):
-            pass
-    threading.Thread(target=_drain, daemon=True).start()
+    startup_complete.set()
     return proc, public_url
 
 
@@ -430,6 +455,60 @@ class SendHandler(BaseHTTPRequestHandler):
     keep_alive: bool = False
     done_event: threading.Event = None  # type: ignore[assignment]
     events: EventLog = None  # type: ignore[assignment]
+    transfer_timeout: float = DEFAULT_TRANSFER_TIMEOUT
+    header_timeout: float = DEFAULT_HEADER_TIMEOUT
+
+    def setup(self) -> None:
+        # Bound both the HTTP header phase and the complete download from the
+        # instant this request starts.
+        self.timeout = min(self.header_timeout, self.transfer_timeout)
+        self._header_timer_lock = threading.Lock()
+        self._header_timer: threading.Timer | None = None
+        self._reading_headers = False
+        self._request_deadline = time.monotonic() + self.transfer_timeout
+        super().setup()
+
+    def handle_one_request(self) -> None:
+        self._start_header_deadline()
+        try:
+            super().handle_one_request()
+        finally:
+            self._finish_header_deadline()
+
+    def parse_request(self) -> bool:
+        try:
+            return super().parse_request()
+        finally:
+            self._finish_header_deadline()
+
+    def _start_header_deadline(self) -> None:
+        header_timeout = min(self.header_timeout, self.transfer_timeout)
+        self.connection.settimeout(header_timeout)
+        self._request_deadline = time.monotonic() + self.transfer_timeout
+        timer = threading.Timer(header_timeout, self._expire_header_read)
+        timer.daemon = True
+        with self._header_timer_lock:
+            self._reading_headers = True
+            self._header_timer = timer
+        timer.start()
+
+    def _finish_header_deadline(self) -> None:
+        with self._header_timer_lock:
+            self._reading_headers = False
+            timer = self._header_timer
+            self._header_timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _expire_header_read(self) -> None:
+        with self._header_timer_lock:
+            if not self._reading_headers:
+                return
+            self._reading_headers = False
+        try:
+            self.connection.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
 
     def log_message(self, fmt, *args):
         print(f"{ANSI_DIM}[{self.address_string()}] {fmt % args}{ANSI_RESET}")
@@ -437,14 +516,27 @@ class SendHandler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802
         if f"/{self.token}/" not in self.path:
             self.send_error(404); return
-        size = self.file_path.stat().st_size
-        self.send_response(200)
-        self.send_header("Content-Type", "application/octet-stream")
-        self.send_header("Content-Length", str(size))
-        self.send_header("Content-Disposition", f'attachment; filename="{quote(self.file_name)}"')
-        self.end_headers()
-        with open(self.file_path, "rb") as f:
-            shutil.copyfileobj(f, self.wfile)
+        try:
+            size = self.file_path.stat().st_size
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(size))
+            self.send_header("Content-Disposition", f'attachment; filename="{quote(self.file_name)}"')
+            self.end_headers()
+            with open(self.file_path, "rb") as f:
+                while chunk := f.read(_DOWNLOAD_CHUNK_SIZE):
+                    remaining = self._request_deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError("download deadline exceeded")
+                    self.connection.settimeout(remaining)
+                    self.wfile.write(chunk)
+                    if time.monotonic() > self._request_deadline:
+                        raise TimeoutError("download deadline exceeded")
+        except OSError:
+            # A failed client must not complete a one-shot session. Closing
+            # only this connection leaves the server available for a retry.
+            self.close_connection = True
+            return
         print(f"{ANSI_FG}{ANSI_BOLD}✓ {self.file_name} envoyé{ANSI_RESET}")
         if self.events:
             self.events.emit(f"TICK {self.file_name}")
@@ -914,6 +1006,7 @@ def cmd_send(args: argparse.Namespace) -> None:
     SendHandler.keep_alive = args.keep_alive
     SendHandler.done_event = threading.Event()
     SendHandler.events = events
+    SendHandler.transfer_timeout = args.transfer_timeout
 
     preferred = args.port or (8080 if args.tunnel else 0)
     server, port = _start_server_with_port(SendHandler, preferred)
@@ -1057,6 +1150,15 @@ def main() -> None:
 
     sp_send = sub.add_parser("send", parents=[common])
     sp_send.add_argument("paths", nargs="+")
+    sp_send.add_argument(
+        "--transfer-timeout",
+        type=_positive_float,
+        default=DEFAULT_TRANSFER_TIMEOUT,
+        help=(
+            "Délai maximal d'un téléchargement en secondes "
+            f"(défaut : {DEFAULT_TRANSFER_TIMEOUT:g}, maximum : {MAX_UPLOAD_TIMEOUT:g})"
+        ),
+    )
     sp_send.set_defaults(func=cmd_send)
 
     sp_recv = sub.add_parser("recv", parents=[common])

--- a/install.sh
+++ b/install.sh
@@ -398,15 +398,27 @@ install_pinned_from_archive() {
 # wipes the managed dirs. They will be restored AFTER the copy.
 stash_preserved_files() {
     PRESERVED_STASH=$(mktemp -d)
-    local count=0
+    local count=0 rel
     for rel in "${PRESERVED_FILES[@]}"; do
         local src="$CONFIG_HOME/$rel"
-        if [[ -f "$src" ]]; then
-            local stash="$PRESERVED_STASH/$rel"
-            mkdir -p "$(dirname "$stash")"
-            cp -a "$src" "$stash"
-            count=$((count + 1))
+        local stash="$PRESERVED_STASH/$rel"
+
+        # Test symlinks lexically before testing their target. A relative link
+        # copied into the private stash is normally dangling there, but `cp -a`
+        # still preserves the exact link text for restoration. Reject links
+        # that are already dangling, or resolve to anything except a regular
+        # file, before deploy_configs replaces any managed directory.
+        if [[ -L "$src" ]]; then
+            [[ -f "$src" ]] || fatal "Preserved path is a dangling symlink or does not resolve to a regular file: $src"
+        elif [[ ! -e "$src" ]]; then
+            continue
+        elif [[ ! -f "$src" ]]; then
+            fatal "Preserved path is not a regular file: $src"
         fi
+
+        mkdir -p "$(dirname "$stash")"
+        cp -a -- "$src" "$stash"
+        count=$((count + 1))
     done
     if (( count > 0 )); then
         ok "Preserved $count user file(s) for restoration after install."
@@ -416,12 +428,18 @@ stash_preserved_files() {
 # Restore preserved files (overwrites whatever the repo copy put in their place).
 restore_preserved_files() {
     [[ -z "$PRESERVED_STASH" || ! -d "$PRESERVED_STASH" ]] && return 0
+    local rel
     for rel in "${PRESERVED_FILES[@]}"; do
         local stash="$PRESERVED_STASH/$rel"
         local dest="$CONFIG_HOME/$rel"
-        if [[ -f "$stash" ]]; then
+        # A stashed relative symlink can be dangling until it returns to its
+        # original directory, so recognize the link object with -L. Remove the
+        # freshly installed template first to avoid destination-dependent cp
+        # behavior and then restore the preserved entry verbatim.
+        if [[ -L "$stash" || -f "$stash" ]]; then
             mkdir -p "$(dirname "$dest")"
-            cp -a "$stash" "$dest"
+            rm -f -- "$dest"
+            cp -a -- "$stash" "$dest"
             ok "Restored user file: $rel"
         fi
     done

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -261,6 +261,90 @@ class InstallerLuaMigrationTests(unittest.TestCase):
         self.assertIn("settings=preserved-settings\n", result.stdout)
         self.assertIn("managed=managed-config\n", result.stdout)
 
+    def test_deploy_preserves_exact_relative_symlinks_for_all_user_files(self) -> None:
+        custom_dir = self.config_home / "custom"
+        custom_dir.mkdir()
+        targets = {
+            "hypr/user.lua": ("../custom/user.lua", "preserved-lua\n"),
+            "hypr/user.conf": ("../custom/user.conf", "preserved-legacy\n"),
+            "quickshell/settings/Settings.qml": (
+                "../../custom/Settings.qml",
+                "preserved-settings\n",
+            ),
+        }
+        for _, (link_text, contents) in targets.items():
+            target = (custom_dir / Path(link_text).name)
+            target.write_text(contents, encoding="utf-8")
+
+        hypr_dir = self.config_home / "hypr"
+        settings_dir = self.config_home / "quickshell/settings"
+        hypr_dir.mkdir()
+        settings_dir.mkdir(parents=True)
+        for rel, (link_text, _) in targets.items():
+            (self.config_home / rel).symlink_to(link_text)
+
+        result = self.run_installer_shell(
+            """
+            mkdir -p "$CLONE_DIR/config/hypr" "$CLONE_DIR/config/quickshell/settings"
+            printf '%s\n' 'managed-config' >"$CLONE_DIR/config/hypr/hyprland.lua"
+            printf '%s\n' 'bundled-user' >"$CLONE_DIR/config/hypr/user.lua"
+            printf '%s\n' 'return {}' >"$CLONE_DIR/config/hypr/tsugumori_options.lua"
+            printf '%s\n' 'bundled-settings' >"$CLONE_DIR/config/quickshell/settings/Settings.qml"
+            BACKUP_OLD=false
+            deploy_configs
+            """
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for rel, (link_text, contents) in targets.items():
+            with self.subTest(rel=rel):
+                restored = self.config_home / rel
+                self.assertTrue(restored.is_symlink())
+                self.assertEqual(os.readlink(restored), link_text)
+                self.assertEqual(restored.read_text(encoding="utf-8"), contents)
+
+    def assert_unsafe_preserved_symlink_fails_before_replacement(
+        self, link_text: str
+    ) -> subprocess.CompletedProcess[str]:
+        hypr_dir = self.config_home / "hypr"
+        hypr_dir.mkdir(parents=True)
+        managed = hypr_dir / "hyprland.lua"
+        managed.write_text("original-config\n", encoding="utf-8")
+        (hypr_dir / "user.lua").symlink_to(link_text)
+
+        result = self.run_installer_shell(
+            """
+            mkdir -p "$CLONE_DIR/config/hypr"
+            printf '%s\n' 'replacement-config' >"$CLONE_DIR/config/hypr/hyprland.lua"
+            printf '%s\n' 'bundled-user' >"$CLONE_DIR/config/hypr/user.lua"
+            printf '%s\n' 'return {}' >"$CLONE_DIR/config/hypr/tsugumori_options.lua"
+            BACKUP_OLD=false
+            deploy_configs
+            """
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(managed.read_text(encoding="utf-8"), "original-config\n")
+        self.assertTrue((hypr_dir / "user.lua").is_symlink())
+        self.assertEqual(os.readlink(hypr_dir / "user.lua"), link_text)
+        return result
+
+    def test_dangling_preserved_symlink_fails_before_config_replacement(self) -> None:
+        result = self.assert_unsafe_preserved_symlink_fails_before_replacement(
+            "../missing-user.lua"
+        )
+
+        self.assertIn("dangling symlink", result.stderr)
+
+    def test_preserved_symlink_to_directory_fails_before_config_replacement(self) -> None:
+        directory_target = self.config_home / "custom-directory"
+        directory_target.mkdir()
+        result = self.assert_unsafe_preserved_symlink_fails_before_replacement(
+            "../custom-directory"
+        )
+
+        self.assertIn("does not resolve to a regular file", result.stderr)
+
     def run_fake_validation(
         self,
         user_source: str,

--- a/tests/test_qshare.py
+++ b/tests/test_qshare.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 import importlib.util
 import io
 from pathlib import Path
@@ -10,6 +10,7 @@ import threading
 import time
 import types
 import unittest
+from unittest import mock
 
 
 QSHARE_PATH = (
@@ -129,6 +130,33 @@ class MemoryConnection:
         released = getattr(self.input, "released", None)
         if released is not None:
             released.set()
+
+
+class DownloadConnection(MemoryConnection):
+    """Record bounded response-body writes and optionally time them out."""
+
+    def __init__(self, request: bytes, *, stall_body: bool = False):
+        super().__init__(request)
+        self.stall_body = stall_body
+        self.headers_sent = False
+        self.body_write_sizes: list[int] = []
+
+    def sendall(self, data: bytes) -> None:
+        if self.headers_sent:
+            self.body_write_sizes.append(len(data))
+            if self.stall_body:
+                raise socket.timeout("simulated stalled download")
+        super().sendall(data)
+        if b"\r\n\r\n" in self.output:
+            self.headers_sent = True
+
+
+class RecordingEvents:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def emit(self, line: str) -> None:
+        self.lines.append(line)
 
 
 def run_handler(
@@ -360,6 +388,90 @@ class QuickshareReceiveTests(unittest.TestCase):
         self.assertEqual((self.output / "saved.bin").read_bytes(), b"saved")
 
 
+class QuickshareSendTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="tsugumori-qshare-send-")
+        self.root = Path(self.tempdir.name)
+        self.payload = self.root / "payload.bin"
+        self.payload.write_bytes(b"x" * (qshare._DOWNLOAD_CHUNK_SIZE + 17))
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def handler(
+        self,
+        *,
+        transfer_timeout: float = 0.5,
+        header_timeout: float = qshare.DEFAULT_HEADER_TIMEOUT,
+        events=None,
+    ):
+        payload = self.payload
+
+        class Handler(qshare.SendHandler):
+            file_path = payload
+            file_name = payload.name
+            token = "test-token"
+            keep_alive = False
+            done_event = threading.Event()
+
+            def log_message(self, _fmt, *_args):
+                pass
+
+        Handler.transfer_timeout = transfer_timeout
+        Handler.header_timeout = header_timeout
+        Handler.events = events
+        return Handler
+
+    @staticmethod
+    def request() -> bytes:
+        return (
+            b"GET /test-token/payload.bin HTTP/1.1\r\n"
+            b"Host: qshare.test\r\nConnection: close\r\n\r\n"
+        )
+
+    def test_partial_headers_hit_absolute_deadline_without_completing(self) -> None:
+        events = RecordingEvents()
+        handler = self.handler(
+            transfer_timeout=5, header_timeout=0.05, events=events
+        )
+        blocked = BlockingInput()
+        connection = MemoryConnection(input_stream=blocked)
+
+        started = time.monotonic()
+        handler(connection, ("memory", 0), types.SimpleNamespace())
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(connection.shutdown_calls, 1)
+        self.assertFalse(handler.done_event.is_set())
+        self.assertEqual(events.lines, [])
+
+    def test_stalled_download_can_retry_and_uses_bounded_chunks(self) -> None:
+        events = RecordingEvents()
+        handler = self.handler(events=events)
+        stalled = DownloadConnection(self.request(), stall_body=True)
+
+        handler(stalled, ("memory", 0), types.SimpleNamespace())
+
+        self.assertFalse(handler.done_event.is_set())
+        self.assertEqual(events.lines, [])
+        self.assertEqual(stalled.body_write_sizes, [qshare._DOWNLOAD_CHUNK_SIZE])
+
+        retry = DownloadConnection(self.request())
+        handler(retry, ("memory", 0), types.SimpleNamespace())
+
+        self.assertTrue(handler.done_event.is_set())
+        self.assertEqual(
+            events.lines,
+            [f"TICK {self.payload.name}", "DONE"],
+        )
+        self.assertEqual(
+            retry.body_write_sizes,
+            [qshare._DOWNLOAD_CHUNK_SIZE, 17],
+        )
+        self.assertTrue(bytes(retry.output).endswith(self.payload.read_bytes()))
+
+
 class QuickshareCliTests(unittest.TestCase):
     def test_upload_timeout_must_be_positive_and_finite(self) -> None:
         self.assertEqual(qshare._positive_float("0.5"), 0.5)
@@ -377,6 +489,107 @@ class QuickshareCliTests(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(qshare.argparse.ArgumentTypeError):
                     qshare._positive_float(value)
+
+
+class QuickshareCloudflareTests(unittest.TestCase):
+    def test_silent_startup_obeys_deadline_and_reaps_process(self) -> None:
+        class SilentStdout:
+            def __init__(self):
+                self.released = threading.Event()
+
+            def readline(self) -> str:
+                self.released.wait(1)
+                return ""
+
+        class SilentProcess:
+            def __init__(self):
+                self.stdout = SilentStdout()
+                self.terminated = False
+                self.reaped = False
+
+            def terminate(self) -> None:
+                self.terminated = True
+                self.stdout.released.set()
+
+            def wait(self, timeout=None) -> int:
+                self.reaped = True
+                return -15
+
+            def kill(self) -> None:
+                self.stdout.released.set()
+
+            def poll(self):
+                return -15 if self.terminated else None
+
+        proc = SilentProcess()
+        started = time.monotonic()
+        with (
+            mock.patch.object(qshare.shutil, "which", return_value="/usr/bin/cloudflared"),
+            mock.patch.object(qshare.subprocess, "Popen", return_value=proc),
+            mock.patch.object(qshare, "CLOUDFLARED_STARTUP_TIMEOUT", 0.05),
+            redirect_stdout(io.StringIO()),
+            self.assertRaises(SystemExit),
+        ):
+            qshare.start_cloudflared(8080)
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 0.5)
+        self.assertTrue(proc.terminated)
+        self.assertTrue(proc.reaped)
+        self.assertNotIn(proc, qshare._CHILD_PROCESSES)
+
+    def test_success_uses_one_reader_that_continues_draining(self) -> None:
+        class SequenceStdout:
+            def __init__(self):
+                self.lines = iter(
+                    [
+                        "https://example.trycloudflare.com\n",
+                        "Registered tunnel connection\n",
+                        "post-startup diagnostic\n",
+                        "",
+                    ]
+                )
+                self.calls = 0
+
+            def readline(self) -> str:
+                self.calls += 1
+                return next(self.lines)
+
+        class RunningProcess:
+            def __init__(self):
+                self.stdout = SequenceStdout()
+
+            def poll(self):
+                return None
+
+            def terminate(self) -> None:
+                pass
+
+        proc = RunningProcess()
+        created_threads = []
+        real_thread = threading.Thread
+
+        def recording_thread(*args, **kwargs):
+            thread = real_thread(*args, **kwargs)
+            created_threads.append(thread)
+            return thread
+
+        try:
+            with (
+                mock.patch.object(qshare.shutil, "which", return_value="/usr/bin/cloudflared"),
+                mock.patch.object(qshare.subprocess, "Popen", return_value=proc),
+                mock.patch.object(qshare.threading, "Thread", side_effect=recording_thread),
+                redirect_stdout(io.StringIO()),
+            ):
+                returned, url = qshare.start_cloudflared(8080)
+
+            created_threads[0].join(0.5)
+            self.assertIs(returned, proc)
+            self.assertEqual(url, "https://example.trycloudflare.com")
+            self.assertEqual(len(created_threads), 1)
+            self.assertEqual(proc.stdout.calls, 4)
+        finally:
+            qshare._CHILD_PROCESSES.discard(proc)
 
 
 class QuickshareServerTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- preserve `user.lua`, dormant `user.conf`, and `Settings.qml` symlinks lexically across installer deployment, while failing closed on dangling or non-file links
- add absolute send-header and download deadlines to Quickshare, bounded streaming, retry-safe one-shot behavior, and `--transfer-timeout`
- replace Cloudflare startup's blocking read loop with a deadline-aware queue and single background pipe reader
- update README timeout guidance and replace the rolling release notes with concise v0.1.1 beta notes

## Why

This closes the urgent installer preservation and Quickshare availability gaps identified after v0.1.0 without expanding into the deferred gallery, Settings migration, pinned-manifest, or hardware-acceptance work.

## Focused local validation

- `python3 -m unittest -v tests.test_installer tests.test_qshare` — 32/32 passed
- `git diff --check` — passed

Per the hotfix plan, the protected `static-checks` job is the single full validation run; no additional VM or live PAM/GPU/multi-monitor cycle was performed.