### PR TITLE
Fix v0.1.2 release blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,14 @@ conflict; fresh installations use Arch's `quickshell` package.
 
 ## Release status
 
-`v0.1.1` is a targeted safety hotfix for Tsugumori's public beta, not a stable
-release. It hardens installer override preservation and adds bounded Quickshare
-send and Cloudflare-tunnel startup deadlines. The focused installer and
-Quickshare test suites cover the hotfix locally, while the complete release tree
-remains gated by the required Arch checks in GitHub Actions. See the
-[`v0.1.1` release notes](RELEASE_NOTES.md) for known limitations.
+`v0.1.2` is a narrow safety hotfix for Tsugumori's public beta, not a stable
+release. It makes the installer reject preserved symlinks that depend on paths
+deployment will replace, and makes Quickshare sends deliver exactly the bytes
+advertised from the opened source file before reporting success. The focused
+installer and Quickshare test suites cover the blocker regressions locally,
+while the complete release tree remains gated by the required Arch checks in
+GitHub Actions. See the [`v0.1.2` release notes](RELEASE_NOTES.md) for known
+limitations.
 
 ## Control Center
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,38 @@
-# Tsugumori v0.1.1
+# Tsugumori v0.1.2
 
-Tsugumori `v0.1.1` is a focused safety hotfix for the public beta. It preserves
-the `v0.1.0` feature set while hardening upgrades and Quickshare connections.
+Tsugumori `v0.1.2` is a narrow safety hotfix for the public beta. It preserves
+the `v0.1.1` feature set while closing two remaining release blockers.
 
 ## Changes
 
-- Installer preservation now handles `user.lua`, dormant `user.conf`, and
-  `Settings.qml` symlinks lexically. Relative link text survives an upgrade
-  unchanged; dangling or non-file preserved links fail closed before the
-  installed configuration is replaced.
-- `qshare send` now applies a fixed 15-second absolute request-header deadline
-  and a five-minute absolute download deadline by default. The new
-  `--transfer-timeout SECONDS` option adjusts the latter, up to the existing
-  24-hour safety maximum. A stalled or disconnected client no longer completes
-  a one-shot send, so another client can retry.
-- Cloudflare tunnel startup now reads output in the background instead of
-  blocking on `readline()`. Its existing 30-second startup limit remains in
-  force, and failed tunnel processes are terminated and reaped.
+- Installer preservation now rejects a preserved symlink when either its
+  lexical destination or resolved target depends on an installer-managed
+  directory. The check runs before deployment mutates configuration; regular
+  preserved files and symlinks whose complete dependency path is external
+  continue to behave as before.
+- `qshare send` now derives `Content-Length` from the opened source file and
+  sends exactly that many bytes. Early EOF fails the attempt without reporting
+  completion or ending the one-shot session, while file growth cannot append
+  bytes beyond the advertised length; a failed attempt remains retryable.
 
 ## Installing this release
 
 Pin both the downloaded installer and the revision it clones:
 
 ```bash
-TSUGUMORI_BRANCH=v0.1.1 bash <(curl -fsSL https://raw.githubusercontent.com/Aleph1-9012/Tsugumori/v0.1.1/install.sh)
+TSUGUMORI_BRANCH=v0.1.2 bash <(curl -fsSL https://raw.githubusercontent.com/Aleph1-9012/Tsugumori/v0.1.2/install.sh)
 ```
 
 The quick-install command in the README intentionally follows rolling `main`;
-the command above installs the immutable `v0.1.1` tree. The historical
-`v0.1.0` notes remain available from that tag and its GitHub release.
+the command above installs the immutable `v0.1.2` tree. The historical
+`v0.1.1` notes remain available from that tag and its GitHub release.
 
 ## Validation
 
-This hotfix uses focused local installer and Quickshare unit suites, followed by
-the protected Arch `Validate` workflow as the full release gate. No additional
-VM, PAM, GPU, or multi-monitor acceptance cycle was run for this patch release.
+This hotfix requires focused local installer and Quickshare unit suites,
+followed by the protected Arch `Validate` workflow on the pull request, the
+exact merged `main` commit, and the exact `v0.1.2` tag. No additional VM, PAM,
+GPU, or multi-monitor acceptance cycle was run for this patch release.
 
 ## Known limitations
 

--- a/config/quickshell/scripts/qshare.py
+++ b/config/quickshell/scripts/qshare.py
@@ -517,19 +517,24 @@ class SendHandler(BaseHTTPRequestHandler):
         if f"/{self.token}/" not in self.path:
             self.send_error(404); return
         try:
-            size = self.file_path.stat().st_size
-            self.send_response(200)
-            self.send_header("Content-Type", "application/octet-stream")
-            self.send_header("Content-Length", str(size))
-            self.send_header("Content-Disposition", f'attachment; filename="{quote(self.file_name)}"')
-            self.end_headers()
-            with open(self.file_path, "rb") as f:
-                while chunk := f.read(_DOWNLOAD_CHUNK_SIZE):
-                    remaining = self._request_deadline - time.monotonic()
-                    if remaining <= 0:
+            with open(self.file_path, "rb", buffering=0) as source:
+                size = os.fstat(source.fileno()).st_size
+                remaining = size
+                self.send_response(200)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(size))
+                self.send_header("Content-Disposition", f'attachment; filename="{quote(self.file_name)}"')
+                self.end_headers()
+                while remaining > 0:
+                    chunk = source.read(min(_DOWNLOAD_CHUNK_SIZE, remaining))
+                    if not chunk:
+                        raise OSError("source ended before advertised length")
+                    timeout = self._request_deadline - time.monotonic()
+                    if timeout <= 0:
                         raise TimeoutError("download deadline exceeded")
-                    self.connection.settimeout(remaining)
+                    self.connection.settimeout(timeout)
                     self.wfile.write(chunk)
+                    remaining -= len(chunk)
                     if time.monotonic() > self._request_deadline:
                         raise TimeoutError("download deadline exceeded")
         except OSError:

--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,11 @@ preflight() {
     command -v pacman >/dev/null || fatal "pacman not found — this script is for Arch Linux only."
     command -v sudo   >/dev/null || fatal "sudo is required."
     command -v curl   >/dev/null || fatal "curl is required for connectivity checks and remote installation."
+    command -v realpath >/dev/null || fatal "GNU realpath is required for safe symlink preservation."
+    if ! realpath --canonicalize-missing --no-symlinks -- / >/dev/null 2>&1 \
+        || ! realpath --canonicalize-existing -- / >/dev/null 2>&1; then
+        fatal "GNU realpath with --canonicalize-missing, --no-symlinks, and --canonicalize-existing support is required for safe symlink preservation."
+    fi
     log "Asking for sudo password upfront…"
     sudo -v || fatal "sudo authentication failed."
     # Keep sudo alive in background
@@ -394,6 +399,167 @@ install_pinned_from_archive() {
 }
 
 # ─── Preserve user files across re-installs ─────────────────────────
+path_is_within() {
+    local candidate="$1" root="$2"
+    if [[ "$root" == "/" ]]; then
+        [[ "$candidate" == /* ]]
+    else
+        [[ "$candidate" == "$root" || "$candidate" == "$root/"* ]]
+    fi
+}
+
+fatal_preserved_symlink_dependency() {
+    local src="$1" link_target="$2" name="$3"
+    fatal "Preserved symlink $src -> $link_target depends on $CONFIG_HOME/$name, and deployment would remove that dependency. Move the target outside installer-managed directories or replace the link with a regular file."
+}
+
+assert_relative_symlink_parent_is_stable() {
+    local src="$1" link_target="$2"
+    local source_parent lexical_parent canonical_parent canonical_config_home
+    local name lexical_root managed_entry parent_suffix future_parent
+
+    [[ "$link_target" != /* ]] || return 0
+
+    source_parent=$(dirname -- "$src")
+    lexical_parent=$(realpath --canonicalize-missing --no-symlinks -- "$source_parent")
+    canonical_parent=$(realpath --canonicalize-existing -- "$source_parent")
+    canonical_config_home=$(realpath --canonicalize-missing -- "$CONFIG_HOME")
+
+    for name in "${MANAGED_DIRS[@]}"; do
+        lexical_root=$(realpath --canonicalize-missing --no-symlinks -- "$CONFIG_HOME/$name")
+        path_is_within "$lexical_parent" "$lexical_root" || continue
+
+        # Deployment replaces the managed entry with a fresh tree. Build the
+        # physical parent path that the restored relative link will use without
+        # following any current symlink at or below that entry. If it differs
+        # from today's parent, the link's anchor would change during deploy.
+        managed_entry=$(realpath --canonicalize-missing --no-symlinks -- "$canonical_config_home/$name")
+        parent_suffix="${lexical_parent#"$lexical_root"}"
+        future_parent=$(realpath --canonicalize-missing --no-symlinks -- "$managed_entry$parent_suffix")
+        if [[ "$canonical_parent" != "$future_parent" ]]; then
+            fatal_preserved_symlink_dependency "$src" "$link_target" "$name"
+        fi
+        return 0
+    done
+}
+
+assert_symlink_resolution_avoids_managed_dirs() {
+    local src="$1" link_target="$2"
+    local resolved pending component probe hop_target name
+    local lexical_root canonical_root managed_entry canonical_config_home
+    local symlink_hops=0
+
+    # Follow the target one path component at a time. GNU realpath gives us the
+    # two endpoint views checked by the caller, but a fully resolved endpoint
+    # does not reveal an outside -> managed -> outside symlink chain. Start
+    # relative targets at the link's existing parent; that parent is deliberately
+    # not treated as a dependency because deployment recreates it before restore.
+    canonical_config_home=$(realpath --canonicalize-missing -- "$CONFIG_HOME")
+    if [[ "$link_target" == /* ]]; then
+        resolved="/"
+        pending="${link_target#/}"
+    else
+        resolved=$(realpath --canonicalize-existing -- "$(dirname -- "$src")")
+        pending="$link_target"
+    fi
+
+    while [[ -n "$pending" ]]; do
+        if [[ "$pending" == */* ]]; then
+            component="${pending%%/*}"
+            pending="${pending#*/}"
+        else
+            component="$pending"
+            pending=""
+        fi
+
+        case "$component" in
+            ""|.) continue ;;
+            ..)
+                if [[ "$resolved" != "/" ]]; then
+                    resolved="${resolved%/*}"
+                    [[ -n "$resolved" ]] || resolved="/"
+                fi
+                continue
+                ;;
+        esac
+
+        if [[ "$resolved" == "/" ]]; then
+            probe="/$component"
+        else
+            probe="$resolved/$component"
+        fi
+
+        for name in "${MANAGED_DIRS[@]}"; do
+            lexical_root=$(realpath --canonicalize-missing --no-symlinks -- "$CONFIG_HOME/$name")
+            canonical_root=$(realpath --canonicalize-missing -- "$CONFIG_HOME/$name")
+            # If CONFIG_HOME is itself a symlink, this is the physical path of
+            # the managed entry without following that entry's final symlink.
+            managed_entry=$(realpath --canonicalize-missing --no-symlinks -- "$canonical_config_home/$name")
+            if path_is_within "$probe" "$lexical_root" \
+                || path_is_within "$probe" "$managed_entry"; then
+                fatal_preserved_symlink_dependency "$src" "$link_target" "$name"
+            fi
+            # Replacing a managed-root symlink removes only the alias, not its
+            # external target tree. Traversal through the alias was caught by
+            # managed_entry above; a direct path to that external tree is safe.
+            if [[ ! -L "$CONFIG_HOME/$name" ]] \
+                && path_is_within "$probe" "$canonical_root"; then
+                fatal_preserved_symlink_dependency "$src" "$link_target" "$name"
+            fi
+        done
+
+        if [[ -L "$probe" ]]; then
+            symlink_hops=$((symlink_hops + 1))
+            (( symlink_hops <= 64 )) \
+                || fatal "Could not safely resolve preserved symlink target after 64 symlink hops: $src"
+            hop_target=$(readlink -- "$probe") \
+                || fatal "Could not inspect preserved symlink dependency: $probe"
+            if [[ "$hop_target" == /* ]]; then
+                resolved="/"
+                hop_target="${hop_target#/}"
+            fi
+            if [[ -n "$pending" ]]; then
+                pending="$hop_target/$pending"
+            else
+                pending="$hop_target"
+            fi
+        else
+            resolved="$probe"
+        fi
+    done
+}
+
+assert_preserved_symlink_survives_deploy() {
+    local src="$1"
+    local link_target lexical_destination canonical_target name
+    local lexical_root canonical_root
+
+    link_target=$(readlink -- "$src") || fatal "Could not read preserved symlink target: $src"
+    if [[ "$link_target" == /* ]]; then
+        lexical_destination="$link_target"
+    else
+        lexical_destination="$(dirname -- "$src")/$link_target"
+    fi
+
+    # Check both the written path and its resolved target: either can depend on
+    # a managed directory even when the other points outside one.
+    lexical_destination=$(realpath --canonicalize-missing --no-symlinks -- "$lexical_destination")
+    canonical_target=$(realpath --canonicalize-existing -- "$src")
+    for name in "${MANAGED_DIRS[@]}"; do
+        lexical_root=$(realpath --canonicalize-missing --no-symlinks -- "$CONFIG_HOME/$name")
+        canonical_root=$(realpath --canonicalize-missing -- "$CONFIG_HOME/$name")
+        if path_is_within "$lexical_destination" "$lexical_root"; then
+            fatal_preserved_symlink_dependency "$src" "$link_target" "$name"
+        fi
+        if [[ ! -L "$CONFIG_HOME/$name" ]] \
+            && path_is_within "$canonical_target" "$canonical_root"; then
+            fatal_preserved_symlink_dependency "$src" "$link_target" "$name"
+        fi
+    done
+    assert_relative_symlink_parent_is_stable "$src" "$link_target"
+    assert_symlink_resolution_avoids_managed_dirs "$src" "$link_target"
+}
+
 # Stash all files listed in PRESERVED_FILES to a temp dir BEFORE deploy_configs
 # wipes the managed dirs. They will be restored AFTER the copy.
 stash_preserved_files() {
@@ -410,6 +576,7 @@ stash_preserved_files() {
         # file, before deploy_configs replaces any managed directory.
         if [[ -L "$src" ]]; then
             [[ -f "$src" ]] || fatal "Preserved path is a dangling symlink or does not resolve to a regular file: $src"
+            assert_preserved_symlink_survives_deploy "$src"
         elif [[ ! -e "$src" ]]; then
             continue
         elif [[ ! -f "$src" ]]; then

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import tempfile
 import textwrap
@@ -44,11 +45,22 @@ class InstallerLuaMigrationTests(unittest.TestCase):
         body: str,
         *,
         extra_env: dict[str, str] | None = None,
+        drop_root_privileges: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         env = self.env.copy()
         if extra_env:
             env.update(extra_env)
         script = 'source "$INSTALLER_UNDER_TEST"\n' + textwrap.dedent(body)
+        identity: dict[str, object] = {}
+        if drop_root_privileges and os.geteuid() == 0:
+            # GitHub's Arch container runs as root, while the installer requires
+            # a normal user. Let this preflight test exercise the next guard.
+            self.root.chmod(0o755)
+            installer_copy = self.root / "install.sh"
+            shutil.copyfile(INSTALLER, installer_copy)
+            installer_copy.chmod(0o644)
+            env["INSTALLER_UNDER_TEST"] = str(installer_copy)
+            identity = {"user": 65534, "group": 65534, "extra_groups": []}
         return subprocess.run(
             ["/usr/bin/bash", "-c", script],
             env=env,
@@ -56,6 +68,7 @@ class InstallerLuaMigrationTests(unittest.TestCase):
             text=True,
             capture_output=True,
             check=False,
+            **identity,
         )
 
     def write_executable(self, name: str, source: str) -> None:
@@ -528,7 +541,10 @@ class InstallerLuaMigrationTests(unittest.TestCase):
         self.assertIn("does not resolve to a regular file", result.stderr)
 
     def test_preflight_rejects_incompatible_realpath_before_sudo(self) -> None:
-        sudo_log = self.root / "sudo.log"
+        sudo_log_dir = self.root / "sudo-log"
+        sudo_log_dir.mkdir()
+        sudo_log_dir.chmod(0o777)
+        sudo_log = sudo_log_dir / "calls"
         self.write_executable("pacman", "#!/bin/sh\nexit 0\n")
         self.write_executable("curl", "#!/bin/sh\nexit 0\n")
         self.write_executable(
@@ -544,6 +560,7 @@ class InstallerLuaMigrationTests(unittest.TestCase):
         result = self.run_installer_shell(
             f'PATH="{self.fake_bin}"\npreflight\n',
             extra_env={"FAKE_SUDO_LOG": str(sudo_log)},
+            drop_root_privileges=True,
         )
 
         self.assertNotEqual(result.returncode, 0)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -303,6 +303,188 @@ class InstallerLuaMigrationTests(unittest.TestCase):
                 self.assertEqual(os.readlink(restored), link_text)
                 self.assertEqual(restored.read_text(encoding="utf-8"), contents)
 
+    def test_external_target_shared_with_managed_alias_survives(self) -> None:
+        external_kitty = self.root / "external-kitty"
+        external_kitty.mkdir()
+        target = external_kitty / "user.lua"
+        target.write_text("external-user\n", encoding="utf-8")
+
+        hypr_dir = self.config_home / "hypr"
+        hypr_dir.mkdir()
+        preserved = hypr_dir / "user.lua"
+        preserved.symlink_to(target)
+        kitty_alias = self.config_home / "kitty"
+        kitty_alias.symlink_to("../external-kitty", target_is_directory=True)
+
+        result = self.run_installer_shell(
+            """
+            mkdir -p "$CLONE_DIR/config/hypr" "$CLONE_DIR/config/kitty"
+            printf '%s\n' 'managed-config' >"$CLONE_DIR/config/hypr/hyprland.lua"
+            printf '%s\n' 'bundled-user' >"$CLONE_DIR/config/hypr/user.lua"
+            printf '%s\n' 'return {}' >"$CLONE_DIR/config/hypr/tsugumori_options.lua"
+            printf '%s\n' 'managed-kitty' >"$CLONE_DIR/config/kitty/kitty.conf"
+            BACKUP_OLD=false
+            deploy_configs
+            """
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(preserved.is_symlink())
+        self.assertEqual(os.readlink(preserved), str(target))
+        self.assertEqual(preserved.read_text(encoding="utf-8"), "external-user\n")
+        self.assertEqual(target.read_text(encoding="utf-8"), "external-user\n")
+        self.assertFalse(kitty_alias.is_symlink())
+        self.assertEqual(
+            (kitty_alias / "kitty.conf").read_text(encoding="utf-8"),
+            "managed-kitty\n",
+        )
+
+    def test_path_is_within_requires_a_path_component_boundary(self) -> None:
+        result = self.run_installer_shell(
+            """
+            root="$CONFIG_HOME/hypr"
+            path_is_within "$root" "$root"
+            path_is_within "$root/user.lua" "$root"
+            ! path_is_within "$CONFIG_HOME/hypr-old/user.lua" "$root"
+            path_is_within "/" "/"
+            path_is_within "/etc/file" "/"
+            """
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_managed_path_symlink_dependencies_fail_before_deployment(self) -> None:
+        cases = (
+            (
+                "same-managed-directory",
+                "hypr/user.lua",
+                "local-user.lua",
+                "direct",
+            ),
+            (
+                "cross-managed-directory",
+                "hypr/user.conf",
+                "../quickshell/local-user.conf",
+                "direct",
+            ),
+            (
+                "managed-intermediate-link",
+                "quickshell/settings/Settings.qml",
+                "../settings-source.qml",
+                "intermediate",
+            ),
+            (
+                "outside-alias-into-managed-directory",
+                "hypr/user.lua",
+                "../outside-alias/aliased-user.lua",
+                "outside-alias",
+            ),
+            (
+                "outside-through-managed-link-to-external-target",
+                "hypr/user.lua",
+                "../outside-chain/user.lua",
+                "outside-managed-outside",
+            ),
+            (
+                "managed-root-alias-changes-relative-link-anchor",
+                "hypr/user.lua",
+                "../external-user.lua",
+                "managed-root-alias",
+            ),
+        )
+
+        for name, preserved_rel, link_text, setup_kind in cases:
+            with self.subTest(case=name):
+                case_root = self.root / name
+                config_home = case_root / "config"
+                hypr_dir = config_home / "hypr"
+                settings_dir = config_home / "quickshell/settings"
+                if setup_kind == "managed-root-alias":
+                    external_hypr = case_root / "external-hypr"
+                    external_hypr.mkdir(parents=True)
+                    config_home.mkdir()
+                    hypr_dir.symlink_to("../external-hypr", target_is_directory=True)
+                else:
+                    hypr_dir.mkdir(parents=True)
+                settings_dir.mkdir(parents=True)
+
+                sentinel = hypr_dir / "managed-sentinel"
+                sentinel.write_bytes(b"original-managed-state\n")
+                if setup_kind == "intermediate":
+                    target = config_home / "external/Settings.qml"
+                    target.parent.mkdir()
+                    intermediate = config_home / "quickshell/settings-source.qml"
+                    intermediate.symlink_to("../external/Settings.qml")
+                elif setup_kind == "outside-alias":
+                    target = hypr_dir / "aliased-user.lua"
+                    alias = config_home / "outside-alias"
+                    alias.symlink_to("hypr", target_is_directory=True)
+                elif setup_kind == "outside-managed-outside":
+                    target = case_root / "external/user.lua"
+                    target.parent.mkdir()
+                    managed_bridge = hypr_dir / "bridge"
+                    managed_bridge.symlink_to(
+                        "../../external", target_is_directory=True
+                    )
+                    alias = config_home / "outside-chain"
+                    alias.symlink_to("hypr/bridge", target_is_directory=True)
+                elif setup_kind == "managed-root-alias":
+                    target = case_root / "external-user.lua"
+                else:
+                    target = (config_home / preserved_rel).parent / link_text
+                    target = target.resolve(strict=False)
+
+                target.write_bytes(f"target-for-{name}\n".encode())
+                preserved = config_home / preserved_rel
+                preserved.parent.mkdir(parents=True, exist_ok=True)
+                preserved.symlink_to(link_text)
+
+                original_sentinel = sentinel.read_bytes()
+                original_target = target.read_bytes()
+                original_link_text = os.readlink(preserved)
+                result = self.run_installer_shell(
+                    """
+                    mkdir -p "$CLONE_DIR/config/hypr" "$CLONE_DIR/config/quickshell/settings"
+                    printf '%s\n' 'replacement-config' >"$CLONE_DIR/config/hypr/hyprland.lua"
+                    printf '%s\n' 'bundled-user' >"$CLONE_DIR/config/hypr/user.lua"
+                    printf '%s\n' 'return {}' >"$CLONE_DIR/config/hypr/tsugumori_options.lua"
+                    printf '%s\n' 'bundled-settings' >"$CLONE_DIR/config/quickshell/settings/Settings.qml"
+                    BACKUP_OLD=false
+                    deploy_configs
+                    """,
+                    extra_env={"XDG_CONFIG_HOME": str(config_home)},
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(str(preserved), result.stderr)
+                self.assertIn(link_text, result.stderr)
+                self.assertIn("deployment would remove", result.stderr)
+                self.assertIn("Move the target outside", result.stderr)
+                self.assertEqual(sentinel.read_bytes(), original_sentinel)
+                self.assertTrue(preserved.is_symlink())
+                self.assertEqual(os.readlink(preserved), original_link_text)
+                self.assertEqual(target.read_bytes(), original_target)
+                if setup_kind == "intermediate":
+                    self.assertTrue(intermediate.is_symlink())
+                    self.assertEqual(
+                        os.readlink(intermediate), "../external/Settings.qml"
+                    )
+                elif setup_kind == "outside-alias":
+                    self.assertTrue(alias.is_symlink())
+                    self.assertEqual(os.readlink(alias), "hypr")
+                elif setup_kind == "outside-managed-outside":
+                    self.assertTrue(alias.is_symlink())
+                    self.assertEqual(os.readlink(alias), "hypr/bridge")
+                    self.assertTrue(managed_bridge.is_symlink())
+                    self.assertEqual(os.readlink(managed_bridge), "../../external")
+                elif setup_kind == "managed-root-alias":
+                    self.assertTrue(hypr_dir.is_symlink())
+                    self.assertEqual(os.readlink(hypr_dir), "../external-hypr")
+                if preserved_rel != "hypr/user.lua":
+                    user_lua = hypr_dir / "user.lua"
+                    self.assertFalse(user_lua.exists())
+                    self.assertFalse(user_lua.is_symlink())
+
     def assert_unsafe_preserved_symlink_fails_before_replacement(
         self, link_text: str
     ) -> subprocess.CompletedProcess[str]:
@@ -344,6 +526,29 @@ class InstallerLuaMigrationTests(unittest.TestCase):
         )
 
         self.assertIn("does not resolve to a regular file", result.stderr)
+
+    def test_preflight_rejects_incompatible_realpath_before_sudo(self) -> None:
+        sudo_log = self.root / "sudo.log"
+        self.write_executable("pacman", "#!/bin/sh\nexit 0\n")
+        self.write_executable("curl", "#!/bin/sh\nexit 0\n")
+        self.write_executable(
+            "sudo",
+            """
+            #!/bin/sh
+            printf 'called\n' >"$FAKE_SUDO_LOG"
+            exit 99
+            """,
+        )
+        self.write_executable("realpath", "#!/bin/sh\nexit 64\n")
+
+        result = self.run_installer_shell(
+            f'PATH="{self.fake_bin}"\npreflight\n',
+            extra_env={"FAKE_SUDO_LOG": str(sudo_log)},
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GNU realpath with --canonicalize-missing", result.stderr)
+        self.assertFalse(sudo_log.exists())
 
     def run_fake_validation(
         self,

--- a/tests/test_qshare.py
+++ b/tests/test_qshare.py
@@ -65,9 +65,19 @@ def request_bytes(
     return b"\r\n".join(headers) + b"\r\n\r\n" + body
 
 
+def parse_response(response: bytes) -> tuple[int, dict[str, str], bytes]:
+    head, body = response.split(b"\r\n\r\n", 1)
+    lines = head.split(b"\r\n")
+    status = int(lines[0].split(b" ", 2)[1])
+    headers = {}
+    for line in lines[1:]:
+        name, value = line.split(b":", 1)
+        headers[name.decode("ascii").lower()] = value.decode("latin-1").strip()
+    return status, headers, body
+
+
 def response_status(response: bytes) -> int:
-    first_line = response.split(b"\r\n", 1)[0]
-    return int(first_line.split(b" ", 2)[1])
+    return parse_response(response)[0]
 
 
 class TimeoutInput(io.BytesIO):
@@ -135,18 +145,30 @@ class MemoryConnection:
 class DownloadConnection(MemoryConnection):
     """Record bounded response-body writes and optionally time them out."""
 
-    def __init__(self, request: bytes, *, stall_body: bool = False):
+    def __init__(
+        self,
+        request: bytes,
+        *,
+        stall_body: bool = False,
+        first_body_write=None,
+    ):
         super().__init__(request)
         self.stall_body = stall_body
+        self.first_body_write = first_body_write
         self.headers_sent = False
         self.body_write_sizes: list[int] = []
 
     def sendall(self, data: bytes) -> None:
-        if self.headers_sent:
+        is_body = self.headers_sent
+        if is_body:
             self.body_write_sizes.append(len(data))
             if self.stall_body:
                 raise socket.timeout("simulated stalled download")
         super().sendall(data)
+        if is_body and self.first_body_write is not None:
+            callback = self.first_body_write
+            self.first_body_write = None
+            callback()
         if b"\r\n\r\n" in self.output:
             self.headers_sent = True
 
@@ -423,10 +445,11 @@ class QuickshareSendTests(unittest.TestCase):
         return Handler
 
     @staticmethod
-    def request() -> bytes:
+    def request(*, keep_alive: bool = False) -> bytes:
+        connection = b"keep-alive" if keep_alive else b"close"
         return (
             b"GET /test-token/payload.bin HTTP/1.1\r\n"
-            b"Host: qshare.test\r\nConnection: close\r\n\r\n"
+            b"Host: qshare.test\r\nConnection: " + connection + b"\r\n\r\n"
         )
 
     def test_partial_headers_hit_absolute_deadline_without_completing(self) -> None:
@@ -470,6 +493,110 @@ class QuickshareSendTests(unittest.TestCase):
             [qshare._DOWNLOAD_CHUNK_SIZE, 17],
         )
         self.assertTrue(bytes(retry.output).endswith(self.payload.read_bytes()))
+
+    def test_truncated_source_does_not_complete_and_retry_succeeds(self) -> None:
+        original = b"x" * (129 * qshare._DOWNLOAD_CHUNK_SIZE + 17)
+        self.payload.write_bytes(original)
+        events = RecordingEvents()
+        base_handler = self.handler(events=events)
+
+        class Handler(base_handler):
+            protocol_version = "HTTP/1.1"
+            close_states: list[bool] = []
+
+            def do_GET(self):  # noqa: N802
+                self.close_states.append(self.close_connection)
+                super().do_GET()
+                self.close_states.append(self.close_connection)
+
+        handler = Handler
+
+        def truncate_source() -> None:
+            with self.payload.open("r+b") as source:
+                source.truncate(qshare._DOWNLOAD_CHUNK_SIZE)
+
+        truncated = DownloadConnection(
+            self.request(keep_alive=True), first_body_write=truncate_source
+        )
+        attempt = handler(truncated, ("memory", 0), types.SimpleNamespace())
+        status, headers, body = parse_response(bytes(truncated.output))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(int(headers["content-length"]), len(original))
+        self.assertEqual(body, original[:len(body)])
+        self.assertLess(len(body), int(headers["content-length"]))
+        self.assertEqual(self.payload.stat().st_size, qshare._DOWNLOAD_CHUNK_SIZE)
+        self.assertEqual(attempt.close_states, [False, True])
+        self.assertTrue(attempt.close_connection)
+        self.assertFalse(handler.done_event.is_set())
+        self.assertEqual(events.lines, [])
+
+        self.payload.write_bytes(original)
+        retry = DownloadConnection(self.request())
+        handler(retry, ("memory", 0), types.SimpleNamespace())
+        retry_status, retry_headers, retry_body = parse_response(bytes(retry.output))
+
+        self.assertEqual(retry_status, 200)
+        self.assertEqual(int(retry_headers["content-length"]), len(original))
+        self.assertEqual(retry_body, original)
+        self.assertTrue(handler.done_event.is_set())
+        self.assertEqual(events.lines, [f"TICK {self.payload.name}", "DONE"])
+
+    def test_path_replacement_keeps_streaming_opened_inode(self) -> None:
+        chunk_size = qshare._DOWNLOAD_CHUNK_SIZE
+        original = b"a" * chunk_size + b"b" * chunk_size + b"old-tail"
+        replacement = b"new-path-bytes"
+        self.payload.write_bytes(original)
+        replacement_path = self.root / "replacement.bin"
+        replacement_path.write_bytes(replacement)
+        events = RecordingEvents()
+        handler = self.handler(events=events)
+        real_fstat = qshare.os.fstat
+
+        def replace_during_fstat(fd: int):
+            replacement_path.replace(self.payload)
+            return real_fstat(fd)
+
+        connection = DownloadConnection(self.request())
+        with mock.patch.object(
+            qshare.os, "fstat", side_effect=replace_during_fstat
+        ) as fstat:
+            handler(connection, ("memory", 0), types.SimpleNamespace())
+        status, headers, body = parse_response(bytes(connection.output))
+
+        fstat.assert_called_once()
+        self.assertEqual(status, 200)
+        self.assertEqual(int(headers["content-length"]), len(original))
+        self.assertEqual(body, original)
+        self.assertEqual(len(body), int(headers["content-length"]))
+        self.assertEqual(self.payload.read_bytes(), replacement)
+        self.assertTrue(handler.done_event.is_set())
+        self.assertEqual(events.lines, [f"TICK {self.payload.name}", "DONE"])
+
+    def test_growth_never_exceeds_advertised_length(self) -> None:
+        original = self.payload.read_bytes()
+        appended = b"appended-after-first-body-write"
+        events = RecordingEvents()
+        handler = self.handler(events=events)
+
+        def grow_source() -> None:
+            with self.payload.open("ab") as source:
+                source.write(appended)
+
+        connection = DownloadConnection(
+            self.request(), first_body_write=grow_source
+        )
+        handler(connection, ("memory", 0), types.SimpleNamespace())
+        status, headers, body = parse_response(bytes(connection.output))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(int(headers["content-length"]), len(original))
+        self.assertEqual(body, original)
+        self.assertEqual(len(body), int(headers["content-length"]))
+        self.assertNotIn(appended, body)
+        self.assertEqual(self.payload.read_bytes(), original + appended)
+        self.assertTrue(handler.done_event.is_set())
+        self.assertEqual(events.lines, [f"TICK {self.payload.name}", "DONE"])
 
 
 class QuickshareCliTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make installer preservation fail closed when a symlink depends on any path deployment will replace, including intermediate resolution hops and changing relative-link anchors
- preserve safe external symlinks, including targets shared with a managed-directory alias
- make Quickshare size and stream from the same opened descriptor, send exactly `Content-Length`, and keep early-EOF failures retryable
- update the public-beta release text and immutable install command for v0.1.2

## Root cause

The installer stashed preserved symlink objects without proving that every path needed to resolve them would survive managed-directory replacement. Quickshare calculated size from the pathname before opening the source and streamed until EOF, so concurrent truncation could still report success and growth could exceed the advertised response length.

## Impact

Risky installer layouts now stop before configuration mutation with an actionable error, while valid external dotfile links continue to survive unchanged. Quickshare only completes after the advertised bytes have been written successfully; truncated attempts remain retryable and appended bytes are excluded.

## Validation

- `TSUGUMORI_REQUIRE_INTEGRATION=1 bash scripts/validate.sh`
- 62 unit tests passed
- ShellCheck errors: none
- Lua and Python syntax checks passed
- Hyprland configuration and 17 QML files validated
- secure-lock assets and package manifests validated
- blocker regressions fail on v0.1.1 and pass with this patch
- `git diff --check`
