### PR TITLE
Stopped terminating user-managed notification daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ A NieR:Automata-style radial menu with Knights of Sidonia theme accessible via `
   - Do Not Disturb toggle silences popups while preserving history
   - Pinned "Clear All" button
 
+> [!NOTE]
+> Tsugumori never stops dunst, mako, swaync, or any other third-party
+> notification daemon. Only one process can own `org.freedesktop.Notifications`
+> at a time, so if such a daemon is running it will keep receiving your
+> notifications and Tsugumori's popups and history will stay empty. To use
+> Tsugumori notifications, disable the competing daemon in its own user service
+> or autostart configuration — see that daemon's documentation for how.
+
 ### Navigation
 
 The menu uses two interaction levels (the internal names retain their original

--- a/config/hypr/hyprland.lua
+++ b/config/hypr/hyprland.lua
@@ -123,9 +123,6 @@ quickshell_command = quickshell_command
 
 hl.on("hyprland.start", function()
     hl.exec_cmd(quickshell_command)
-    hl.exec_cmd("pkill dunst")
-    hl.exec_cmd("pkill mako")
-    hl.exec_cmd("pkill swaync")
     hl.exec_cmd(quickshell_script("lock.sh"))
     hl.exec_cmd("hypridle")
     hl.exec_cmd("udiskie")

--- a/config/quickshell/widgets/Notifications.qml
+++ b/config/quickshell/widgets/Notifications.qml
@@ -2,7 +2,8 @@
 // Daemon de notifications style NieR / YoRHa
 //
 // Installation :
-//   1. Tuer tout autre daemon : pkill dunst; pkill mako; pkill swaync
+//   1. Disable any other notification daemon (dunst, mako, swaync) via its own
+//      service or autostart configuration; Tsugumori never terminates them.
 //   2. qs -p notifications.qml
 //
 // Tests :

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -72,6 +72,11 @@ if rg -n 'pkill[[:space:]]+(-[^[:space:]]+[[:space:]]+)*qs([[:space:]]|$)' confi
     exit 1
 fi
 
+if rg -n '\b(pkill|killall)\b.*\b(dunst|mako|swaync)\b' config; then
+    printf 'Tsugumori must not terminate user-managed notification daemons.\n' >&2
+    exit 1
+fi
+
 LOCK_QML=config/quickshell/widgets/lockscreen.qml
 for token in 'WlSessionLock {' 'locked: true' 'WlSessionLockSurface {' 'PamContext {' 'config: "hyprlock"' '!sessionLock.secure' 'Quickshell.watchFiles = false'; do
     if ! rg -Fq "$token" "$LOCK_QML"; then


### PR DESCRIPTION
## Summary
What does this PR change, and why?

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Config/theme tweak
- [ ] Documentation
- [ ] Other (describe below)

## Testing
How did you verify this works? (e.g. ran `install.sh`, tested on Hyprland version X, checked in a VM)

## Checklist
- [ ] I've tested this on my own system
- [ ] I've updated `VERSIONS.md` / `packages/` if this changes a dependency
- [ ] I've updated the README if this changes user-facing behavior
