### PR TITLE
fix: prevent menu clipping

### DIFF
--- a/config/quickshell/widgets/Menu.qml
+++ b/config/quickshell/widgets/Menu.qml
@@ -444,6 +444,13 @@ Item {
                                     }
                                     height: parent.height
 
+				    Behavior on anchors.leftMargin {
+				        NumberAnimation {
+				            duration: 180
+				            easing.type: Easing.OutQuart
+        			        }
+				    }
+				    
                                     Text {
                                         id: appId
                                         anchors {

--- a/config/quickshell/widgets/Menu.qml
+++ b/config/quickshell/widgets/Menu.qml
@@ -250,7 +250,7 @@ Item {
                         Rectangle { width:24; height:1; color:root.inkSoft; anchors.verticalCenter:parent.verticalCenter }
                         Text { text:"システム"; font.pixelSize:10; font.letterSpacing:2; color:root.inkSoft }
                     }
-                    Item { width:parent.width - width-425; height:1 }
+                    Item { width:parent.width - 370; height:1 }
                     Row {
                         spacing:14; anchors.verticalCenter:parent.verticalCenter
                         Item {
@@ -433,59 +433,122 @@ Item {
                                     x:24; width:parent.width-48; height:1; color:root.lineSoft; opacity:0.5
                                 }
 
-                                Row {
+                                Item {
+                                    id: appRow
                                     anchors {
-                                        left:parent.left; right:parent.right; verticalCenter:parent.verticalCenter
-                                        leftMargin:  appMA.containsMouse||appDelegate.isFocused ? 32 : 24
+                                        left: parent.left
+                                        right: parent.right
+                                        verticalCenter: parent.verticalCenter
+                                        leftMargin: appMA.containsMouse || appDelegate.isFocused ? 32 : 24
                                         rightMargin: 24
                                     }
-                                    spacing:14
-                                    Behavior on anchors.leftMargin { NumberAnimation { duration:180; easing.type:Easing.OutQuart } }
+                                    height: parent.height
 
                                     Text {
-                                        anchors.verticalCenter:parent.verticalCenter
-                                        text:modelData.id; width:22; font.pixelSize:9; font.letterSpacing:1.5
-                                        color: appMA.containsMouse||appDelegate.isFocused ? Qt.rgba(10/255,10/255,10/255,0.75) : root.inkSoft
+                                        id: appId
+                                        anchors {
+                                            left: parent.left
+                                            verticalCenter: parent.verticalCenter
+                                        }
+                                        width: 22
+                                        text: modelData.id
+                                        font.pixelSize: 9
+                                        font.letterSpacing: 1.5
+                                        color: appMA.containsMouse || appDelegate.isFocused
+                                               ? Qt.rgba(10/255,10/255,10/255,0.75)
+                                               : root.inkSoft
                                         Behavior on color { ColorAnimation { duration:120 } }
                                     }
+
                                     Rectangle {
-                                        anchors.verticalCenter:parent.verticalCenter
-                                        width:28; height:28; color:"transparent"
-                                        border.color: appMA.containsMouse||appDelegate.isFocused ? Qt.rgba(10/255,10/255,10/255,0.6) : root.ink
-                                        border.width:1
+                                        id: appIcon
+                                        anchors {
+                                            left: appId.right
+                                            leftMargin: 14
+                                            verticalCenter: parent.verticalCenter
+                                        }
+                                        width: 28
+                                        height: 28
+                                        color: "transparent"
+                                        border.color: appMA.containsMouse || appDelegate.isFocused
+                                                      ? Qt.rgba(10/255,10/255,10/255,0.6)
+                                                      : root.ink
+                                        border.width: 1
                                         Behavior on border.color { ColorAnimation { duration:120 } }
+
                                         Text {
-                                            anchors.centerIn:parent; text:modelData.icon; font.pixelSize:12
-                                            color: appMA.containsMouse||appDelegate.isFocused ? "#0a0a0a" : root.ink
+                                            anchors.centerIn: parent
+                                            text: modelData.icon
+                                            font.pixelSize: 12
+                                            color: appMA.containsMouse || appDelegate.isFocused
+                                                   ? "#0a0a0a" : root.ink
                                             Behavior on color { ColorAnimation { duration:120 } }
                                         }
                                     }
+
+                                    Row {
+                                        id: appRightInfo
+                                        anchors {
+                                            right: parent.right
+                                            verticalCenter: parent.verticalCenter
+                                        }
+                                        spacing: 14
+
+                                        Text {
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            text: (root.catLabels[modelData.cat] || modelData.cat).toUpperCase()
+                                            font.pixelSize: 9
+                                            font.letterSpacing: 2
+                                            color: appMA.containsMouse || appDelegate.isFocused
+                                                   ? Qt.rgba(10/255,10/255,10/255,0.65)
+                                                   : root.inkSoft
+                                            Behavior on color { ColorAnimation { duration:120 } }
+                                        }
+
+                                        Text {
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            text: "▸"
+                                            font.pixelSize: 14
+                                            color: root.accent
+                                            opacity: appMA.containsMouse || appDelegate.isFocused ? 1 : 0
+                                            Behavior on opacity { NumberAnimation { duration:120 } }
+                                        }
+                                    }
+
                                     Column {
-                                        anchors.verticalCenter:parent.verticalCenter; spacing:2
+                                        id: appInfo
+                                        anchors {
+                                            left: appIcon.right
+                                            right: appRightInfo.left
+                                            leftMargin: 14
+                                            rightMargin: 20
+                                            verticalCenter: parent.verticalCenter
+                                        }
+                                        spacing: 2
+
                                         Text {
-                                            text:modelData.name; font.pixelSize:12; font.letterSpacing:1.2; font.weight:Font.Medium
-                                            color: appMA.containsMouse||appDelegate.isFocused ? "#0a0a0a" : root.ink
+                                            width: parent.width
+                                            text: modelData.name
+                                            elide: Text.ElideRight
+                                            font.pixelSize: 12
+                                            font.letterSpacing: 1.2
+                                            font.weight: Font.Medium
+                                            color: appMA.containsMouse || appDelegate.isFocused
+                                                   ? "#0a0a0a" : root.ink
                                             Behavior on color { ColorAnimation { duration:120 } }
                                         }
+
                                         Text {
-                                            text:modelData.meta; font.pixelSize:9; font.letterSpacing:1.5
-                                            color: appMA.containsMouse||appDelegate.isFocused ? Qt.rgba(10/255,10/255,10/255,0.75) : root.inkSoft
+                                            width: parent.width
+                                            text: modelData.meta
+                                            elide: Text.ElideRight
+                                            font.pixelSize: 9
+                                            font.letterSpacing: 1.5
+                                            color: appMA.containsMouse || appDelegate.isFocused
+                                                   ? Qt.rgba(10/255,10/255,10/255,0.75)
+                                                   : root.inkSoft
                                             Behavior on color { ColorAnimation { duration:120 } }
                                         }
-                                    }
-                                    Item { width:appList.width-480; height:1 }
-                                    Text {
-                                        anchors.verticalCenter:parent.verticalCenter
-                                        text:(root.catLabels[modelData.cat]||modelData.cat).toUpperCase()
-                                        font.pixelSize:9; font.letterSpacing:2
-                                        color: appMA.containsMouse||appDelegate.isFocused ? Qt.rgba(10/255,10/255,10/255,0.65) : root.inkSoft
-                                        Behavior on color { ColorAnimation { duration:120 } }
-                                    }
-                                    Text {
-                                        anchors.verticalCenter:parent.verticalCenter
-                                        text:"▸"; font.pixelSize:14; color:root.accent
-                                        opacity: appMA.containsMouse||appDelegate.isFocused ? 1 : 0
-                                        Behavior on opacity { NumberAnimation { duration:120 } }
                                     }
                                 }
 

--- a/config/quickshell/widgets/Menu.qml
+++ b/config/quickshell/widgets/Menu.qml
@@ -250,7 +250,7 @@ Item {
                         Rectangle { width:24; height:1; color:root.inkSoft; anchors.verticalCenter:parent.verticalCenter }
                         Text { text:"システム"; font.pixelSize:10; font.letterSpacing:2; color:root.inkSoft }
                     }
-                    Item { width:parent.width - 340; height:1 }
+                    Item { width:parent.width - width-425; height:1 }
                     Row {
                         spacing:14; anchors.verticalCenter:parent.verticalCenter
                         Item {
@@ -473,7 +473,7 @@ Item {
                                             Behavior on color { ColorAnimation { duration:120 } }
                                         }
                                     }
-                                    Item { width:appList.width-310; height:1 }
+                                    Item { width:appList.width-480; height:1 }
                                     Text {
                                         anchors.verticalCenter:parent.verticalCenter
                                         text:(root.catLabels[modelData.cat]||modelData.cat).toUpperCase()


### PR DESCRIPTION
## Summary
What does this PR change, and why?
On the app launcher menu, by default bound to Super, the app labels clip beyond the right edge due to the width of the spacer defined between app titles and the labels. I've created 2 possible fixes, available in 2 separate commits.
FIX 1- REDUCE SPACER WIDTH (First commit)
<img width="2489" height="1660" alt="20260825_190040" src="https://github.com/user-attachments/assets/03c9d601-ee86-4d2e-9d50-b2a31e37b4cc" />

FIX 2- MENU RESTRUCTURE (Second commit)
<img width="2496" height="1664" alt="20260825_191347" src="https://github.com/user-attachments/assets/758f68dc-67c9-432f-80d2-bdd6bf4fd826" />


## Type of change
- [x] Bug fix
- [  ] New feature
- [x] Config/theme tweak
- [  ] Documentation
- [  ] Other (describe below)

## Testing
How did you verify this works?
Tested on my personal system. hyprland 0.56.2-1, quickshell 0.3.1-1.1

## Checklist
- [x] I've tested this on my own system
- [  ] I've updated `VERSIONS.md` / `packages/` if this changes a dependency
- [  ] I've updated the README if this changes user-facing behavior
